### PR TITLE
feat: add short interactive aliases for common cmdlets

### DIFF
--- a/src/Convert/Convert.psd1
+++ b/src/Convert/Convert.psd1
@@ -117,6 +117,19 @@
         'ConvertFrom-Base64StringToByteArray'
         'ConvertFrom-ByteArrayToBase64String'
         'ConvertFrom-StreamToString'
+        'cfb64'
+        'cfurl'
+        'cfut'
+        'ctb64'
+        'ctc'
+        'ctf'
+        'cthash'
+        'cthmac'
+        'ctstr'
+        'cttc'
+        'cturl'
+        'ctut'
+        'gut'
     )
 
     # DSC resources to export from this module

--- a/src/Convert/Convert.psd1
+++ b/src/Convert/Convert.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'Convert.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '2.0.7'
+    ModuleVersion        = '2.0.8'
 
     # Supported PSEditions
     CompatiblePSEditions = @(

--- a/src/Convert/Public/ConvertFrom-Base64ToString.ps1
+++ b/src/Convert/Public/ConvertFrom-Base64ToString.ps1
@@ -59,7 +59,7 @@
 function ConvertFrom-Base64ToString {
     [CmdletBinding(HelpUri = 'https://austoonz.github.io/Convert/functions/ConvertFrom-Base64ToString/')]
     [OutputType('String')]
-    [Alias('ConvertFrom-Base64StringToString')]
+    [Alias('ConvertFrom-Base64StringToString', 'cfb64')]
     param
     (
         [Parameter(

--- a/src/Convert/Public/ConvertFrom-EscapedUrl.ps1
+++ b/src/Convert/Public/ConvertFrom-EscapedUrl.ps1
@@ -21,6 +21,7 @@
 #>
 function ConvertFrom-EscapedUrl {
     [CmdletBinding()]
+    [Alias('cfurl')]
     param (
         [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]

--- a/src/Convert/Public/ConvertFrom-UnixTime.ps1
+++ b/src/Convert/Public/ConvertFrom-UnixTime.ps1
@@ -35,6 +35,7 @@
 #>
 function ConvertFrom-UnixTime {
     [CmdletBinding()]
+    [Alias('cfut')]
     param (
         # The Unix time to convert. Represented in seconds by default, or in milliseconds if the FromMilliseconds
         # parameter is specified.

--- a/src/Convert/Public/ConvertTo-Base64.ps1
+++ b/src/Convert/Public/ConvertTo-Base64.ps1
@@ -142,6 +142,7 @@ function ConvertTo-Base64 {
     [CmdletBinding(
         DefaultParameterSetName = 'String',
         HelpUri = 'https://austoonz.github.io/Convert/functions/ConvertTo-Base64/')]
+    [Alias('ctb64')]
     param
     (
         [Parameter(

--- a/src/Convert/Public/ConvertTo-Celsius.ps1
+++ b/src/Convert/Public/ConvertTo-Celsius.ps1
@@ -66,6 +66,7 @@ function ConvertTo-Celsius {
     [CmdletBinding()]
     [OutputType([double])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
+    [Alias('ctc')]
     param (
         [Parameter(Mandatory = $true,
             ValueFromPipeline = $true,

--- a/src/Convert/Public/ConvertTo-EscapedUrl.ps1
+++ b/src/Convert/Public/ConvertTo-EscapedUrl.ps1
@@ -21,6 +21,7 @@
 #>
 function ConvertTo-EscapedUrl {
     [CmdletBinding()]
+    [Alias('cturl')]
     param (
         [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]

--- a/src/Convert/Public/ConvertTo-Fahrenheit.ps1
+++ b/src/Convert/Public/ConvertTo-Fahrenheit.ps1
@@ -65,6 +65,7 @@
 function ConvertTo-Fahrenheit {
     [CmdletBinding()]
     [OutputType([double])]
+    [Alias('ctf')]
     param (
         [Parameter(Mandatory = $true,
             ValueFromPipeline = $true,

--- a/src/Convert/Public/ConvertTo-Hash.ps1
+++ b/src/Convert/Public/ConvertTo-Hash.ps1
@@ -23,6 +23,7 @@
 #>
 function ConvertTo-Hash {
     [CmdletBinding()]
+    [Alias('cthash')]
     param (
         [Parameter(ParameterSetName = 'String', ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [string[]]$String,

--- a/src/Convert/Public/ConvertTo-HmacHash.ps1
+++ b/src/Convert/Public/ConvertTo-HmacHash.ps1
@@ -92,6 +92,7 @@
 function ConvertTo-HmacHash {
     [CmdletBinding(DefaultParameterSetName = 'ProvidedKey')]
     [OutputType([String], [Byte[]], [PSCustomObject])]
+    [Alias('cthmac')]
     param (
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [AllowNull()]

--- a/src/Convert/Public/ConvertTo-String.ps1
+++ b/src/Convert/Public/ConvertTo-String.ps1
@@ -87,6 +87,7 @@ function ConvertTo-String {
     [CmdletBinding(
         DefaultParameterSetName = 'Base64String',
         HelpUri = 'https://austoonz.github.io/Convert/functions/ConvertTo-String/')]
+    [Alias('ctstr')]
     param
     (
         [Parameter(

--- a/src/Convert/Public/ConvertTo-TitleCase.ps1
+++ b/src/Convert/Public/ConvertTo-TitleCase.ps1
@@ -21,6 +21,7 @@
 #>
 function ConvertTo-TitleCase {
     [CmdletBinding()]
+    [Alias('cttc')]
     param (
         [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]

--- a/src/Convert/Public/ConvertTo-UnixTime.ps1
+++ b/src/Convert/Public/ConvertTo-UnixTime.ps1
@@ -36,6 +36,7 @@
 #>
 function ConvertTo-UnixTime {
     [CmdletBinding()]
+    [Alias('ctut')]
     param (
         # A DateTime object representing the time to convert. Defaults to `[datetime]::UtcNow`.
         [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName)]

--- a/src/Convert/Public/Get-UnixTime.ps1
+++ b/src/Convert/Public/Get-UnixTime.ps1
@@ -26,6 +26,7 @@
 #>
 function Get-UnixTime {
     [CmdletBinding()]
+    [Alias('gut')]
     param (
         # If specified, returns the time in milliseconds that have elapsed since 00:00:00 UTC on 1 January, 1970.
         [switch]$AsMilliseconds

--- a/src/Tests/Unit/ConvertFrom-Base64ToString.Tests.ps1
+++ b/src/Tests/Unit/ConvertFrom-Base64ToString.Tests.ps1
@@ -226,8 +226,14 @@ Describe -Name $function -Fixture {
         It -Name 'Returns correct type' -Test {
             $base64 = 'VGhpc0lzTXlTdHJpbmc='
             $result = ConvertFrom-Base64ToString -String $base64 -Encoding 'UTF8'
-            
+
             $result | Should -BeOfType [string]
+        }
+    }
+
+    Context -Name 'Alias' -Fixture {
+        It -Name 'cfb64 resolves to ConvertFrom-Base64ToString' -Test {
+            (Get-Alias -Name 'cfb64').ResolvedCommand | Should -BeExactly 'ConvertFrom-Base64ToString'
         }
     }
 }

--- a/src/Tests/Unit/ConvertFrom-EscapedUrl.Tests.ps1
+++ b/src/Tests/Unit/ConvertFrom-EscapedUrl.Tests.ps1
@@ -45,4 +45,10 @@ Describe $function {
             $err | Should -Not -BeNullOrEmpty
         }
     }
+
+    Context -Name 'Alias' -Fixture {
+        It -Name 'cfurl resolves to ConvertFrom-EscapedUrl' -Test {
+            (Get-Alias -Name 'cfurl').ResolvedCommand | Should -BeExactly 'ConvertFrom-EscapedUrl'
+        }
+    }
 }

--- a/src/Tests/Unit/ConvertFrom-UnixTime.Tests.ps1
+++ b/src/Tests/Unit/ConvertFrom-UnixTime.Tests.ps1
@@ -140,4 +140,10 @@ Describe -Name $function -Fixture {
             $result | Should -BeOfType [datetime]
         }
     }
+
+    Context -Name 'Alias' -Fixture {
+        It -Name 'cfut resolves to ConvertFrom-UnixTime' -Test {
+            (Get-Alias -Name 'cfut').ResolvedCommand | Should -BeExactly 'ConvertFrom-UnixTime'
+        }
+    }
 }

--- a/src/Tests/Unit/ConvertTo-Base64.Tests.ps1
+++ b/src/Tests/Unit/ConvertTo-Base64.Tests.ps1
@@ -228,4 +228,10 @@ Describe -Name $function -Fixture {
             $result | Should -Not -BeNullOrEmpty
         }
     }
+
+    Context -Name 'Alias' -Fixture {
+        It -Name 'ctb64 resolves to ConvertTo-Base64' -Test {
+            (Get-Alias -Name 'ctb64').ResolvedCommand | Should -BeExactly 'ConvertTo-Base64'
+        }
+    }
 }

--- a/src/Tests/Unit/ConvertTo-Celsius.Tests.ps1
+++ b/src/Tests/Unit/ConvertTo-Celsius.Tests.ps1
@@ -138,4 +138,10 @@ Describe $function {
             $result | Should -BeOfType [double]
         }
     }
+
+    Context 'Alias' {
+        It 'ctc resolves to ConvertTo-Celsius' {
+            (Get-Alias -Name 'ctc').ResolvedCommand | Should -BeExactly 'ConvertTo-Celsius'
+        }
+    }
 }

--- a/src/Tests/Unit/ConvertTo-EscapedUrl.Tests.ps1
+++ b/src/Tests/Unit/ConvertTo-EscapedUrl.Tests.ps1
@@ -185,4 +185,10 @@ Describe $function {
             $result | Should -Match '%'
         }
     }
+
+    Context -Name 'Alias' -Fixture {
+        It -Name 'cturl resolves to ConvertTo-EscapedUrl' -Test {
+            (Get-Alias -Name 'cturl').ResolvedCommand | Should -BeExactly 'ConvertTo-EscapedUrl'
+        }
+    }
 }

--- a/src/Tests/Unit/ConvertTo-Fahrenheit.Tests.ps1
+++ b/src/Tests/Unit/ConvertTo-Fahrenheit.Tests.ps1
@@ -138,4 +138,10 @@ Describe $function {
             $result | Should -BeOfType [double]
         }
     }
+
+    Context 'Alias' {
+        It 'ctf resolves to ConvertTo-Fahrenheit' {
+            (Get-Alias -Name 'ctf').ResolvedCommand | Should -BeExactly 'ConvertTo-Fahrenheit'
+        }
+    }
 }

--- a/src/Tests/Unit/ConvertTo-Hash.Tests.ps1
+++ b/src/Tests/Unit/ConvertTo-Hash.Tests.ps1
@@ -10,7 +10,7 @@ Describe -Name $function -Fixture {
     }
 
     Context -Name 'Algorithm Support' -Fixture {
-        It -Name 'Computes <Algorithm> hash correctly' -TestCases @(
+        It -Name 'Computes <Algorithm> hash correctly' -ForEach @(
             @{
                 Algorithm = 'MD5'
                 Expected = '441BE86C39533902C582CB7C8BEB7CF4'
@@ -164,7 +164,7 @@ Describe -Name $function -Fixture {
             $result2 | Should -BeExactly $result3
         }
 
-        It -Name 'Produces valid hex output format for <Algorithm>' -TestCases @(
+        It -Name 'Produces valid hex output format for <Algorithm>' -ForEach @(
             @{Algorithm = 'MD5'; Length = 32}
             @{Algorithm = 'SHA1'; Length = 40}
             @{Algorithm = 'SHA256'; Length = 64}
@@ -193,6 +193,12 @@ Describe -Name $function -Fixture {
             
             # For ASCII-compatible strings, UTF8 and ASCII should produce same hash
             $utf8Result | Should -BeExactly $asciiResult
+        }
+    }
+
+    Context -Name 'Alias' -Fixture {
+        It -Name 'cthash resolves to ConvertTo-Hash' -Test {
+            (Get-Alias -Name 'cthash').ResolvedCommand | Should -BeExactly 'ConvertTo-Hash'
         }
     }
 }

--- a/src/Tests/Unit/ConvertTo-HmacHash.Tests.ps1
+++ b/src/Tests/Unit/ConvertTo-HmacHash.Tests.ps1
@@ -50,7 +50,7 @@ Describe -Name $function -Fixture {
     }
 
     Context -Name 'Algorithm Validation' -Fixture {
-        It -Name "Produces correct HMAC with <Algorithm>" -TestCases @(
+        It -Name "Produces correct HMAC with <Algorithm>" -ForEach @(
             @{ Algorithm = 'HMACSHA256' }
             @{ Algorithm = 'HMACSHA384' }
             @{ Algorithm = 'HMACSHA512' }
@@ -112,7 +112,7 @@ Describe -Name $function -Fixture {
     }
 
     Context -Name 'Encoding Options' -Fixture {
-        It -Name "Handles different text encodings" -TestCases @(
+        It -Name "Handles different text encodings" -ForEach @(
             @{ Encoding = 'UTF8'; Data = "Test String with special chars: äöü" }
             @{ Encoding = 'ASCII'; Data = "Test String with ASCII only chars" }
             @{ Encoding = 'Unicode'; Data = "Test String with special chars: äöü" }
@@ -396,7 +396,7 @@ Describe -Name $function -Fixture {
             $stream.Dispose()
         }
 
-        It -Name "Supports all output formats with Rust" -TestCases @(
+        It -Name "Supports all output formats with Rust" -ForEach @(
             @{ Format = 'Hex'; ExpectedLength = 64; ExpectedType = 'String' }
             @{ Format = 'Base64'; ExpectedType = 'String' }
             @{ Format = 'ByteArray'; ExpectedLength = 32; ExpectedType = 'Byte' }
@@ -461,6 +461,12 @@ Describe -Name $function -Fixture {
             # Test with null input and SilentlyContinue
             $result = ConvertTo-HmacHash -InputObject $null -Key $key -ErrorAction SilentlyContinue
             $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context -Name 'Alias' -Fixture {
+        It -Name 'cthmac resolves to ConvertTo-HmacHash' -Test {
+            (Get-Alias -Name 'cthmac').ResolvedCommand | Should -BeExactly 'ConvertTo-HmacHash'
         }
     }
 }

--- a/src/Tests/Unit/ConvertTo-String.Tests.ps1
+++ b/src/Tests/Unit/ConvertTo-String.Tests.ps1
@@ -198,4 +198,10 @@ Describe -Name $function -Fixture {
             $writer2.Dispose()
         }
     }
+
+    Context -Name 'Alias' -Fixture {
+        It -Name 'ctstr resolves to ConvertTo-String' -Test {
+            (Get-Alias -Name 'ctstr').ResolvedCommand | Should -BeExactly 'ConvertTo-String'
+        }
+    }
 }

--- a/src/Tests/Unit/ConvertTo-TitleCase.Tests.ps1
+++ b/src/Tests/Unit/ConvertTo-TitleCase.Tests.ps1
@@ -28,4 +28,10 @@ Describe $function {
         $assertion = $strings | ConvertTo-TitleCase
         $assertion | Should -BeExactly $expected
     }
+
+    Context 'Alias' {
+        It 'cttc resolves to ConvertTo-TitleCase' {
+            (Get-Alias -Name 'cttc').ResolvedCommand | Should -BeExactly 'ConvertTo-TitleCase'
+        }
+    }
 }

--- a/src/Tests/Unit/ConvertTo-UnixTime.Tests.ps1
+++ b/src/Tests/Unit/ConvertTo-UnixTime.Tests.ps1
@@ -155,4 +155,10 @@ Describe -Name $function -Fixture {
             $result | Should -BeOfType [long]
         }
     }
+
+    Context -Name 'Alias' -Fixture {
+        It -Name 'ctut resolves to ConvertTo-UnixTime' -Test {
+            (Get-Alias -Name 'ctut').ResolvedCommand | Should -BeExactly 'ConvertTo-UnixTime'
+        }
+    }
 }

--- a/src/Tests/Unit/Get-UnixTime.Tests.ps1
+++ b/src/Tests/Unit/Get-UnixTime.Tests.ps1
@@ -34,4 +34,10 @@ Describe -Name $function -Fixture {
             (($epochTime + [System.TimeSpan]::FromMilliseconds($assertion)) - $now).TotalMilliseconds | Should -BeLessThan 1000
         }
     }
+
+    Context -Name 'Alias' -Fixture {
+        It -Name 'gut resolves to Get-UnixTime' -Test {
+            (Get-Alias -Name 'gut').ResolvedCommand | Should -BeExactly 'Get-UnixTime'
+        }
+    }
 }

--- a/src/Tests/Unit/Global.Tests.ps1
+++ b/src/Tests/Unit/Global.Tests.ps1
@@ -18,7 +18,7 @@ Describe -Name 'Module Manifest' -Fixture {
         $assertion.ToString().Split('.') | Should -HaveCount 3
     }
 
-    It -Name 'Is compatible with PSEdition: <_>' -TestCases @(
+    It -Name 'Is compatible with PSEdition: <_>' -ForEach @(
         'Core'
         'Desktop'
     ) -Test {
@@ -42,7 +42,7 @@ Describe -Name 'Module Manifest' -Fixture {
             $assertion | Should -HaveCount 31
         }
 
-        It -Name '<_>' -TestCases @(
+        It -Name '<_>' -ForEach @(
             'ConvertFrom-Base64'
             'ConvertFrom-Base64ToByteArray'
             'ConvertFrom-Base64ToMemoryStream'
@@ -86,11 +86,11 @@ Describe -Name 'Module Manifest' -Fixture {
     }
 
     Context -Name 'Exported Aliases' -Fixture {
-        It -Name 'Exports three aliases' -Test {
-            ($script:Manifest).ExportedAliases.GetEnumerator() | Should -HaveCount 3
+        It -Name 'Exports sixteen aliases' -Test {
+            ($script:Manifest).ExportedAliases.GetEnumerator() | Should -HaveCount 16
         }
 
-        It -Name '<Alias>' -TestCases @(
+        It -Name '<Alias>' -ForEach @(
             @{
                 Alias           = 'ConvertFrom-Base64StringToByteArray'
                 ResolvedCommand = 'ConvertFrom-Base64ToByteArray'
@@ -102,6 +102,58 @@ Describe -Name 'Module Manifest' -Fixture {
             @{
                 Alias           = 'ConvertFrom-StreamToString'
                 ResolvedCommand = 'ConvertFrom-MemoryStreamToString'
+            }
+            @{
+                Alias           = 'cfb64'
+                ResolvedCommand = 'ConvertFrom-Base64ToString'
+            }
+            @{
+                Alias           = 'cfurl'
+                ResolvedCommand = 'ConvertFrom-EscapedUrl'
+            }
+            @{
+                Alias           = 'cfut'
+                ResolvedCommand = 'ConvertFrom-UnixTime'
+            }
+            @{
+                Alias           = 'ctb64'
+                ResolvedCommand = 'ConvertTo-Base64'
+            }
+            @{
+                Alias           = 'ctc'
+                ResolvedCommand = 'ConvertTo-Celsius'
+            }
+            @{
+                Alias           = 'ctf'
+                ResolvedCommand = 'ConvertTo-Fahrenheit'
+            }
+            @{
+                Alias           = 'cthash'
+                ResolvedCommand = 'ConvertTo-Hash'
+            }
+            @{
+                Alias           = 'cthmac'
+                ResolvedCommand = 'ConvertTo-HmacHash'
+            }
+            @{
+                Alias           = 'ctstr'
+                ResolvedCommand = 'ConvertTo-String'
+            }
+            @{
+                Alias           = 'cttc'
+                ResolvedCommand = 'ConvertTo-TitleCase'
+            }
+            @{
+                Alias           = 'cturl'
+                ResolvedCommand = 'ConvertTo-EscapedUrl'
+            }
+            @{
+                Alias           = 'ctut'
+                ResolvedCommand = 'ConvertTo-UnixTime'
+            }
+            @{
+                Alias           = 'gut'
+                ResolvedCommand = 'Get-UnixTime'
             }
         ) -Test {
             $assertion = Get-Alias -Name $Alias


### PR DESCRIPTION
## Summary

Adds 13 short `ct`/`cf`-prefixed aliases targeting cmdlets used interactively. The full module surface is not aliased — MemoryStream, CompressedByteArray, HashTable, and SecureString cmdlets are excluded as they are primarily used inside scripts where full names aid readability.

The three existing compatibility aliases (`ConvertFrom-Base64StringToByteArray`, `ConvertFrom-ByteArrayToBase64String`, `ConvertFrom-StreamToString`) are retained.

| Alias | Cmdlet |
|-------|--------|
| `ctb64` | `ConvertTo-Base64` |
| `cfb64` | `ConvertFrom-Base64ToString` |
| `cthash` | `ConvertTo-Hash` |
| `cthmac` | `ConvertTo-HmacHash` |
| `cturl` | `ConvertTo-EscapedUrl` |
| `cfurl` | `ConvertFrom-EscapedUrl` |
| `ctut` | `ConvertTo-UnixTime` |
| `cfut` | `ConvertFrom-UnixTime` |
| `gut` | `Get-UnixTime` |
| `ctc` | `ConvertTo-Celsius` |
| `ctf` | `ConvertTo-Fahrenheit` |
| `cttc` | `ConvertTo-TitleCase` |
| `ctstr` | `ConvertTo-String` |

`cfb64` targets `ConvertFrom-Base64ToString` (not `ConvertFrom-Base64`) because it has lenient mode — UTF-8 with Latin-1 fallback when no encoding is specified — making it more forgiving for interactive use.

All aliases were verified against the PowerShell Gallery with `Find-Module -Command` — no collisions found.

Closes #26

## Test plan

- [ ] `Global.Tests.ps1` asserts 16 exported aliases with full metadata verification (source, version, resolved command, visibility) for each
- [ ] Each affected cmdlet's test file has an `Alias` context that asserts the short alias resolves to the correct function — prevents silent removal or remapping
- [ ] Remaining `-TestCases` usages migrated to `-ForEach` in `Global.Tests.ps1`, `ConvertTo-Hash.Tests.ps1`, and `ConvertTo-HmacHash.Tests.ps1`
- [ ] Run `.\build.ps1 -PowerShell -Test` to confirm all tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)